### PR TITLE
Preserve failed benchmark attempts

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -2039,6 +2039,8 @@ benchmarks the
 Since version 8.11.0, it is possible to have extra benchmark metrics with the command ``--benchmark-extended``:
 
 * `jobid`: Internal job ID,
+* `attempt`: One-based execution attempt number,
+* `status`: Attempt outcome (`success`, `failed`, or `aborted`),
 * `rule_name`: Rule name,
 * `wildcards`: Job wildcards,
 * `params`: Job parameters,
@@ -2048,6 +2050,10 @@ Since version 8.11.0, it is possible to have extra benchmark metrics with the co
 * `input_size_mb`: Size of input files (MiB),
 
 of the command ``somecommand`` for the given output and input files.
+
+Extended benchmark files preserve one row for a failed or aborted attempt and
+append later retry attempts to the same file. This makes retry cost and runtime
+auditable without replacing the failed-attempt record with the successful one.
 
 For this, the shell or run body of the rule is executed on that data, and all run times are stored into the given benchmark `tsv` file (which will contain a tab-separated table of run times and memory usage in MiB).
 Per default, Snakemake executes the job once, generating one run time.

--- a/snakemake/benchmark.py
+++ b/snakemake/benchmark.py
@@ -41,6 +41,8 @@ class BenchmarkRecord:
         if extended_fmt:
             header += [
                 "jobid",
+                "attempt",
+                "status",
                 "rule_name",
                 "wildcards",
                 "params",
@@ -55,6 +57,8 @@ class BenchmarkRecord:
     def __init__(
         self,
         jobid=None,
+        attempt=None,
+        status=None,
         rule_name=None,
         wildcards=None,
         params=None,
@@ -73,6 +77,10 @@ class BenchmarkRecord:
     ):
         #: Job ID
         self.jobid = (jobid,)
+        #: One-based execution attempt number
+        self.attempt = attempt
+        #: Attempt outcome (success, failed, or aborted)
+        self.status = status
         #: Rule name
         self.rule_name = (rule_name,)
         #: Job wildcards
@@ -113,6 +121,13 @@ class BenchmarkRecord:
         self.skipped_procs = set()
         #: Track if data has been collected
         self.data_collected = False
+        #: Wrapper timestamp used when a failure occurs before a process timer starts
+        self.start_time = time.time()
+
+    def finalize(self):
+        """Ensure failed or aborted attempts still have an elapsed runtime."""
+        if self.running_time is None:
+            self.running_time = time.time() - self.start_time
 
     def timedelta_to_str(self, x):
         """Conversion of timedelta to str without fractions of seconds"""
@@ -187,6 +202,8 @@ class BenchmarkRecord:
         if extended_fmt:
             record += [
                 self.jobid,
+                self.attempt,
+                self.status,
                 self.rule_name,
                 self.parse_wildcards(),
                 self.parse_params(),
@@ -427,15 +444,18 @@ def benchmarked(pid=None, benchmark_record=None, interval=BENCHMARK_INTERVAL):
         start_time = time.time()
         bench_thread = BenchmarkTimer(int(pid or os.getpid()), result, interval)
         bench_thread.start()
-        yield result
-        bench_thread.cancel()
-        result.running_time = time.time() - start_time
+        try:
+            yield result
+        finally:
+            bench_thread.cancel()
+            result.running_time = time.time() - start_time
 
 
-def print_benchmark_tsv(records, file_, extended_fmt):
+def print_benchmark_tsv(records, file_, extended_fmt, include_header=True):
     """Write benchmark records to file-like the object"""
     logger.debug("Benchmarks in TSV format")
-    print("\t".join(BenchmarkRecord.get_header(extended_fmt)), file=file_)
+    if include_header:
+        print("\t".join(BenchmarkRecord.get_header(extended_fmt)), file=file_)
     for r in records:
         print(r.to_tsv(extended_fmt), file=file_)
 
@@ -447,10 +467,16 @@ def print_benchmark_jsonl(records, file_, extended_fmt):
         print(r.to_json(extended_fmt), file=file_)
 
 
-def write_benchmark_records(records, path, extended_fmt):
+def write_benchmark_records(records, path, extended_fmt, append=False):
     """Write benchmark records to file at path"""
-    with open(path, "wt") as f:
+    path_exists = os.path.exists(path) and os.path.getsize(path) > 0
+    with open(path, "at" if append else "wt") as f:
         if path.endswith(".jsonl"):
             print_benchmark_jsonl(records, f, extended_fmt)
         else:
-            print_benchmark_tsv(records, f, extended_fmt)
+            print_benchmark_tsv(
+                records,
+                f,
+                extended_fmt,
+                include_header=not append or not path_exists,
+            )

--- a/snakemake/executors/local.py
+++ b/snakemake/executors/local.py
@@ -161,6 +161,7 @@ class Executor(RealExecutor):
             self.workflow.execution_settings.cleanup_scripts,
             job.shadow_dir,
             job.jobid,
+            job.attempt,
             (
                 self.workflow.execution_settings.edit_notebook
                 if self.dag.is_edit_notebook_job(job)
@@ -300,6 +301,7 @@ def run_wrapper(
     cleanup_scripts,
     shadow_dir,
     jobid,
+    attempt,
     edit_notebook,
     conda_base_path,
     basedir,
@@ -330,7 +332,6 @@ def run_wrapper(
         from snakemake.benchmark import (
             BenchmarkRecord,
             benchmarked,
-            write_benchmark_records,
         )
 
     # Change workdir if shadow defined and not using singularity.
@@ -340,10 +341,10 @@ def run_wrapper(
         passed_shadow_dir = shadow_dir
         shadow_dir = None
 
+    bench_records = []
     try:
         with change_working_directory(shadow_dir):
             if benchmark:
-                bench_records = []
                 for bench_iteration in range(benchmark_repeats):
                     # Determine whether to benchmark this process or do not
                     # benchmarking at all.  We benchmark this process unless the
@@ -355,11 +356,12 @@ def run_wrapper(
                         or job_rule.wrapper
                         or job_rule.cwl
                     )
+                    bench_record = BenchmarkRecord(attempt=attempt, status="failed")
+                    bench_records.append(bench_record)
                     if is_sub:
                         # The benchmarking through ``benchmarked()`` is started
                         # in the execution of the shell fragment, script, wrapper
                         # etc, as the child PID is available there.
-                        bench_record = BenchmarkRecord()
                         run(
                             input,
                             output,
@@ -390,7 +392,7 @@ def run_wrapper(
                         # The benchmarking is started here as we have a run section
                         # and the generated Python function is executed in this
                         # process' thread.
-                        with benchmarked() as bench_record:
+                        with benchmarked(benchmark_record=bench_record):
                             run(
                                 input,
                                 output,
@@ -417,8 +419,7 @@ def run_wrapper(
                                 sourcecache_path,
                                 runtime_sourcecache_path,
                             )
-                    # Store benchmark record for this iteration
-                    bench_records.append(bench_record)
+                    bench_record.status = "success"
             else:
                 run(
                     input,
@@ -449,8 +450,37 @@ def run_wrapper(
     except (KeyboardInterrupt, SystemExit) as e:
         # Re-raise the keyboard interrupt in order to record an error in the
         # scheduler but ignore it
+        for bench_record in bench_records:
+            if bench_record.status == "failed":
+                bench_record.status = "aborted"
+        _write_benchmark_records_for_job(
+            bench_records,
+            benchmark,
+            benchmark_extended,
+            attempt,
+            job_rule,
+            jobid,
+            wildcards,
+            params,
+            resources,
+            input,
+            threads,
+        )
         raise e
     except BaseException as ex:
+        _write_benchmark_records_for_job(
+            bench_records,
+            benchmark,
+            benchmark_extended,
+            attempt,
+            job_rule,
+            jobid,
+            wildcards,
+            params,
+            resources,
+            input,
+            threads,
+        )
         # this ensures that exception can be re-raised in the parent thread
         origin = get_exception_origin(ex, linemaps)
         if origin is not None:
@@ -465,17 +495,55 @@ def run_wrapper(
             # some internal bug, just reraise
             raise ex
 
-    if benchmark is not None:
-        try:
-            # Add job info to (all repeats of) benchmark file
-            for bench_record in bench_records:
-                bench_record.jobid = jobid
-                bench_record.rule_name = job_rule.name
-                bench_record.wildcards = wildcards
-                bench_record.params = params
-                bench_record.resources = resources
-                bench_record.input = input
-                bench_record.threads = threads
-            write_benchmark_records(bench_records, benchmark, benchmark_extended)
-        except Exception as ex:
-            raise WorkflowError(ex)
+    _write_benchmark_records_for_job(
+        bench_records,
+        benchmark,
+        benchmark_extended,
+        attempt,
+        job_rule,
+        jobid,
+        wildcards,
+        params,
+        resources,
+        input,
+        threads,
+    )
+
+
+def _write_benchmark_records_for_job(
+    bench_records,
+    benchmark,
+    benchmark_extended,
+    attempt,
+    job_rule,
+    jobid,
+    wildcards,
+    params,
+    resources,
+    input,
+    threads,
+):
+    if benchmark is None or not bench_records:
+        return
+
+    from snakemake.benchmark import write_benchmark_records
+
+    try:
+        for bench_record in bench_records:
+            bench_record.finalize()
+            bench_record.jobid = jobid
+            bench_record.attempt = attempt
+            bench_record.rule_name = job_rule.name
+            bench_record.wildcards = wildcards
+            bench_record.params = params
+            bench_record.resources = resources
+            bench_record.input = input
+            bench_record.threads = threads
+        write_benchmark_records(
+            bench_records,
+            benchmark,
+            benchmark_extended,
+            append=attempt > 1,
+        )
+    except Exception as ex:
+        raise WorkflowError(ex)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import csv
 import os
 import shutil
 import sys
@@ -368,6 +369,80 @@ def test_benchmark():
 @skip_on_windows
 def test_benchmark_jsonl():
     run(dpath("test_benchmark_jsonl"), benchmark_extended=True, check_md5=False)
+
+
+@skip_on_windows
+def test_failed_benchmark_attempts_are_preserved(tmp_path):
+    (tmp_path / "Snakefile").write_text(
+        """
+from pathlib import Path
+
+
+rule all:
+    input:
+        "done.txt",
+        "shell-done.txt",
+
+
+rule retried:
+    output:
+        "done.txt"
+    benchmark:
+        "benchmark.tsv"
+    run:
+        marker = Path(".first_attempt_finished")
+        if not marker.exists():
+            marker.touch()
+            raise ValueError("intentional first-attempt failure")
+        Path(output[0]).write_text("done\\n")
+
+
+rule shell_retried:
+    output:
+        "shell-done.txt"
+    benchmark:
+        "shell-benchmark.tsv"
+    shell:
+        "if [[ ! -e .first_shell_attempt_finished ]]; then "
+        "touch .first_shell_attempt_finished; exit 1; "
+        "else printf 'shell done\\\\n' > {output}; fi"
+"""
+    )
+    sp.run(
+        [
+            sys.executable,
+            "-m",
+            "snakemake",
+            "--scheduler",
+            "greedy",
+            "--retries",
+            "1",
+            "--benchmark-extended",
+            "--cores",
+            "1",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    with (tmp_path / "benchmark.tsv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [(row["attempt"], row["status"]) for row in rows] == [
+        ("1", "failed"),
+        ("2", "success"),
+    ]
+    assert [row["rule_name"] for row in rows] == ["retried", "retried"]
+
+    with (tmp_path / "shell-benchmark.tsv").open(newline="") as handle:
+        shell_rows = list(csv.DictReader(handle, delimiter="\t"))
+    assert [(row["attempt"], row["status"]) for row in shell_rows] == [
+        ("1", "failed"),
+        ("2", "success"),
+    ]
+    assert [row["rule_name"] for row in shell_rows] == [
+        "shell_retried",
+        "shell_retried",
+    ]
 
 
 def test_temp_expand():


### PR DESCRIPTION
## Summary

- add `attempt` and `status` to extended benchmark records
- write failed and aborted attempt rows before propagating job errors
- append retry records without duplicating TSV headers
- cover run and shell retries with an intentional failure-then-success regression

## Validation

- repository-era Black check: passed
- focused retry regression: 1 passed
- TSV and JSONL retry serialization: passed
- Python compileall: passed
- `git diff --check`: passed

## Local environment limitation

The two existing ILP-scheduled benchmark fixture tests cannot start on this ARM Mac because the repository virtual environment bundles an x86_64 CBC executable. The new regression uses the greedy scheduler and passes; the TSV and JSONL serialization paths were also exercised directly.