### PR TITLE
Support unprefixed release tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 [tool.versioneer]
 VCS = "git"
 style = "pep440"
-tag_prefix = "v"
+tag_prefix = ""
 versionfile_build = "snakemake/_version.py"
 versionfile_source = "snakemake/_version.py"
 


### PR DESCRIPTION
## Summary

Configure Versioneer to accept the fork release convention of annotated, unprefixed numeric tags.

## Validation

A temporary local annotated `8.25.4` tag on this commit produced package version `8.25.4`; the tag was deleted before pushing this branch.